### PR TITLE
Fl command line tool

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/commons/io/CommandLineTool.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/CommandLineTool.scala
@@ -46,7 +46,7 @@ trait CommandLineTool extends LazyLogging {
     * scala> import com.fulcrumgenomics.commons.io._
     * scala> val TestArgs = Seq("--version")
     * scala> val Executable = "Rscript"
-    * scala> Rscript.execCommand(Executable +: TestArgs:_*)
+    * scala> Rscript.execCommand(Executable +: TestArgs: _*)
     * res1: scala.util.Try[scala.collection.mutable.ListBuffer[String]] = Success(ListBuffer(R scripting front-end version 3.5.1 (2018-07-02)))
     * }}}
     * */
@@ -92,7 +92,7 @@ trait ScriptRunner {
     * @param args a variable list of arguments to pass to the script
     */
   def execIfAvailable(scriptResource: String, args: String*): Unit =
-    try { if (Available) exec(scriptResource, args:_*) }
+    try { if (Available) exec(scriptResource, args: _*) }
     catch { case e: Exception => throw new Exception(s"Cannot execute script from $scriptResource with args:$args") }
 
   /** Executes a script stored at a Path if the this executable is available.
@@ -110,7 +110,7 @@ trait ScriptRunner {
     * @param scriptResource the name of the script resource on the classpath
     * @param args a variable list of arguments to pass to the script
     */
-  def exec(scriptResource: String, args: String*): Unit = exec(writeResourceToTempFile(scriptResource), args:_*)
+  def exec(scriptResource: String, args: String*): Unit = exec(writeResourceToTempFile(scriptResource), args: _*)
 
   /** Executes a script from the filesystem Path.
     *
@@ -156,7 +156,7 @@ trait Versioned {
   val TestArgs: Seq[String] = Seq(VersionFlag)
 
   /** Returns version of this executable. */
-  lazy val Version: Try[ListBuffer[String]] = execCommand(Executable +: TestArgs:_*)
+  lazy val Version: Try[ListBuffer[String]] = execCommand(Executable +: TestArgs: _*)
 }
 
 /** Defines methods used to check if specific modules are installed with the executable . */
@@ -196,11 +196,11 @@ object Rscript extends CommandLineTool with Versioned with Modular with ScriptRu
     * */
   def TestModuleCommand(module: String): Seq[String] = Seq(Executable, "-e", s"stopifnot(require('$module'))")
 
-  /** Only returns true if R exists and ggplot2 is installed */
-  override lazy val Available: Boolean = {
-    val ToolAvailable: Boolean   = execCommand(Executable +: Seq(VersionFlag):_*).isSuccess
-    Seq(ToolAvailable, ModuleAvailable("ggplot2")).forall( _ == true)
-  }
+  /** Only returns true if Rscript exists. */
+  override lazy val Available: Boolean = execCommand(Executable, VersionFlag).isSuccess
+
+  /** Only returns true if both Rscript exists and the library ggplot2 is installed. */
+  lazy val ggplot2Available: Boolean = Available && ModuleAvailable("ggplot2")
 }
 
 /** Defines tools to test various version of python executables */

--- a/src/main/scala/com/fulcrumgenomics/commons/io/CommandLineTool.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/CommandLineTool.scala
@@ -1,0 +1,167 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.commons.io
+
+import java.nio.file.{Files, Path}
+
+import com.fulcrumgenomics.commons.util.LazyLogging
+
+import scala.io.Source
+
+import scala.util.{Success, Try}
+
+trait CommandLineTool extends LazyLogging {
+  /** The name of the executable such as Rscript or gs. */
+  val Executable: String
+
+  /** Command used for the above executable. */
+  val TestCommand: Seq[String]
+
+  /** Exception class that holds onto an executable's exit/status code. */
+  case class ToolException(status: Int) extends RuntimeException {
+    override def getMessage: String = s"$Executable failed with exit code $status."
+  }
+
+
+  /** Returns a tuple of (Boolean, String): first element is true when command can execute
+    *  with no error; second element is a string of command stdout */
+  def execArgs(command: String*):(Boolean, String) = {
+    try {
+      // Create temp file for storing stdout result
+      val output = Files.createTempFile("output.", ".txt")
+      output.toFile.deleteOnExit()
+
+      // Redirect stdout to the temp file & start process
+      val process = new ProcessBuilder(command: _*)
+        .redirectErrorStream(true)
+        .redirectOutput(output.toFile)
+        .start()
+
+      // True if the command can execute with no error
+      val canExecute: Boolean = process.waitFor() == 0
+
+      // Read redirected stdout to a string
+      val bufferedSource      = Source.fromFile(output.toString)
+      val lines: String       = bufferedSource.getLines().mkString
+      bufferedSource.close()
+
+      (canExecute, lines)
+    }
+    catch { case e: Exception => (false, "") }
+  }
+
+  /** Returns true if the tool is available and false otherwise. */
+  lazy val Available: Boolean = {
+    execArgs(Executable +: TestCommand:_*)._1
+  }
+}
+
+trait CanRunScript {
+  self: CommandLineTool =>
+  /** Suffix for scripts that can be run by this tool. */
+  val Suffix: String
+
+  /** Executes a script from the classpath if the tested executable is available. */
+  def execIfAvailable(scriptResource: String, args: String*): Try[Unit] =
+    if (Available) exec(scriptResource, args:_*) else Success(Unit)
+
+  /** Executes from a script stored at a Path if the tested executable is available. */
+  def execIfAvailable(script: Path, args: String*): Try[Unit] =
+    if (Available) exec(script, args:_*) else Success(Unit)
+
+  /** Executes a script from the classpath. */
+  def exec(scriptResource: String, args: String*): Try[Unit] =
+    Try { writeResourceToTempFile(scriptResource) }.map(path => exec(path, args:_*))
+
+  /** Executes from a script stored at a Path. */
+  def exec(script: Path, args: String*): Try[Unit] = Try {
+    val command = Executable +: script.toAbsolutePath.toString +: args
+    val process = new ProcessBuilder(command:_*).redirectErrorStream(false).start()
+    val pipe1   = Io.pipeStream(process.getErrorStream, logger.info)
+    val pipe2   = Io.pipeStream(process.getInputStream, logger.debug)
+    val retval  = process.waitFor()
+    pipe1.close()
+    pipe2.close()
+
+    if (retval != 0) throw ToolException(retval)
+  }
+
+  /** Extracts a resource from the classpath and writes it to a temp file on disk. */
+  private def writeResourceToTempFile(resource: String): Path = {
+    val lines = Io.readLinesFromResource(resource).toSeq
+    val path = Io.makeTempFile("script.", suffix = Suffix)
+    path.toFile.deleteOnExit()
+    Io.writeLines(path, lines)
+    path
+  }
+}
+
+trait Versioned {
+  self: CommandLineTool =>
+  val VersionFlag: String      = "--version"
+  val TestCommand: Seq[String] = Seq(VersionFlag)
+
+  /** Returns version of the tool */
+  lazy val Version: String     = execArgs(Executable +: TestCommand:_*)._2
+}
+
+trait Modular {
+  self: CommandLineTool =>
+
+  /** Command used to test if a module is included with the tested executable. */
+  def TestModuleCommand(module: String): Seq[String]
+
+  /** Command used to test if multiple modules are included with the tested executable. */
+  def TestModuleCommand(modules: Seq[String]): Seq[Seq[String]] = modules.map(TestModuleCommand)
+
+  /** Returns true if the tested module exist with the tested executable. */
+  def IsModuleAvailable(module: String): Boolean                = execArgs(TestModuleCommand(module): _*)._1
+
+  /** Returns true if all tested modules exist with the tested executable. */
+  def IsModuleAvailable(modules: Seq[String]): Boolean          =  modules.map(IsModuleAvailable).forall(x => x == true)
+}
+
+object Rscript extends CommandLineTool with Versioned with Modular with CanRunScript {
+  val Executable: String      = "Rscript"
+  val Suffix: String          = ".R"
+  def TestModuleCommand(module: String): Seq[String] = Seq(Executable, "-e", s"stopifnot(require('$module'))")
+
+  /** Only returns true if R exists and ggplot2 is installed */
+  override lazy val Available: Boolean = {
+    val ToolAvailable: Boolean    = execArgs(Executable +: Seq(VersionFlag):_*)._1
+    val ModuleAvailable : Boolean = IsModuleAvailable(module = "ggplot2")
+    Seq(ToolAvailable, ModuleAvailable).forall( _ == true)
+  }
+}
+
+object GhostScript extends CommandLineTool with Versioned {
+  val Executable: String = "gs"
+}
+
+object Python3 extends CommandLineTool with Versioned with Modular with CanRunScript {
+  val Executable: String                             = "python3"
+  val Suffix: String                                 = ".py"
+  def TestModuleCommand(module: String): Seq[String] = Seq(Executable, "-c", s"'import $module'")
+}

--- a/src/main/scala/com/fulcrumgenomics/commons/io/CommandLineTool.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/CommandLineTool.scala
@@ -25,8 +25,10 @@ package com.fulcrumgenomics.commons.io
 
 import java.nio.file.Path
 
+import com.fulcrumgenomics.commons.CommonsDef
 import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.commons.CommonsDef._
+//import com.fulcrumgenomics.commons.io.Python.executable
 
 import scala.collection.mutable.ListBuffer
 import scala.util.Try
@@ -42,7 +44,7 @@ trait CommandLineTool extends LazyLogging {
   /** The name of the executable. */
   val executable: String
 
-  /** Arguments for the above executable.
+  /** Arguments for the executable.
     *
     * For example, to run `Rscript --version`:
     * {{{
@@ -212,13 +214,16 @@ object Rscript extends CommandLineTool with Versioned with Modular with ScriptRu
 }
 
 /** Defines tools to test various version of python executables */
-trait Python extends CommandLineTool with Versioned with Modular with ScriptRunner {
-  val executable: String
+class Python (val pythonVersion: String, val executable: String = "python") extends
+  CommandLineTool with Versioned with Modular with ScriptRunner {
   val suffix: FilenameSuffix = ".py"
   def TestModuleCommand(module: String): Seq[String] = Seq(executable, "-c", s"import $module")
 }
 
 /** Objects specific for different Python versions.  */
-object Python extends Python  { val executable: String = "python" }
-object Python2 extends Python { val executable: String = "python2" }
-object Python3 extends Python { val executable: String = "python3" }
+object Python {
+  def apply(pythonVersion : String = "", executable: String = "python" ) =
+    new Python(pythonVersion, f"$executable$pythonVersion")
+  val Python2 = new Python("2")
+  val Python3 = new Python("3")
+}

--- a/src/main/scala/com/fulcrumgenomics/commons/io/CommandLineTool.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/CommandLineTool.scala
@@ -214,16 +214,18 @@ object Rscript extends CommandLineTool with Versioned with Modular with ScriptRu
 }
 
 /** Defines tools to test various version of python executables */
-class Python private(val pythonVersion: String, val executable: String = "python") extends
-  CommandLineTool with Versioned with Modular with ScriptRunner {
-  val suffix: FilenameSuffix = ".py"
+trait Python extends CommandLineTool with Versioned with Modular with ScriptRunner {
+  val executable: String                             = "python"
+  val suffix: FilenameSuffix                         = ".py"
   def TestModuleCommand(module: String): Seq[String] = Seq(executable, "-c", s"import $module")
 }
 
-/** Objects specific for different Python versions.  */
-object Python {
-  def apply(pythonVersion : String = "", executable: String = "python" ) =
-    new Python(pythonVersion, f"$executable$pythonVersion")
-  val Python2 = new Python("2")
-  val Python3 = new Python("3")
-}
+/** Major Python versions as traits.  */
+trait Python2 extends Python { override val executable = "python2"}
+trait Python3 extends Python { override val executable = "python3"}
+
+/** Popular major and minor Python versions.  */
+object Python2 extends Python2
+object Python3 extends Python3
+object Python2_7 extends Python2  { override val executable: String = "python2.7" }
+object Python3_7 extends Python3  { override val executable: String = "python3.7" }

--- a/src/main/scala/com/fulcrumgenomics/commons/io/CommandLineTool.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/CommandLineTool.scala
@@ -214,7 +214,7 @@ object Rscript extends CommandLineTool with Versioned with Modular with ScriptRu
 }
 
 /** Defines tools to test various version of python executables */
-class Python (val pythonVersion: String, val executable: String = "python") extends
+class Python private(val pythonVersion: String, val executable: String = "python") extends
   CommandLineTool with Versioned with Modular with ScriptRunner {
   val suffix: FilenameSuffix = ".py"
   def TestModuleCommand(module: String): Seq[String] = Seq(executable, "-c", s"import $module")

--- a/src/main/scala/com/fulcrumgenomics/commons/io/CommandLineTool.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/CommandLineTool.scala
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017 Fulcrum Genomics LLC
+ * Copyright (c) 2019 Fulcrum Genomics LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,34 +21,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package com.fulcrumgenomics.commons.io
 
 import java.nio.file.Path
 
 import com.fulcrumgenomics.commons.util.LazyLogging
+import com.fulcrumgenomics.commons.CommonsDef._
 
 import scala.collection.mutable.ListBuffer
 import scala.util.Try
 
+/** Provides methods for an executable to run it. For example, methods to run this
+  * executable using provided arguments, test if this executable is available, etc.
+  */
 trait CommandLineTool extends LazyLogging {
 
-  /** The name of the executable such as Rscript or gs. */
+  /** The name of the executable. */
   val Executable: String
 
-  /** Command used for the above executable.
+  /** Arguments for the above executable.
     *
     * For example, to run `Rscript --version`:
     * {{{
     * scala> import com.fulcrumgenomics.commons.io._
     * scala> val TestArgs = Seq("--version")
     * scala> val Executable = "Rscript"
-    * scala> Rscript.execArgs(Executable +: TestArgs:_*)
+    * scala> Rscript.execCommand(Executable +: TestArgs:_*)
+    * res1: scala.util.Try[scala.collection.mutable.ListBuffer[String]] = Success(ListBuffer(R scripting front-end version 3.5.1 (2018-07-02)))
     * }}}
     * */
   val TestArgs: Seq[String]
 
-  /** Exception class that holds onto an executable's exit/status code. */
+  /** Exception class that holds onto the exit/status code of the executable. */
   case class ToolException(status: Int) extends RuntimeException {
     override def getMessage: String = s"$Executable failed with exit code $status."
   }
@@ -57,7 +61,7 @@ trait CommandLineTool extends LazyLogging {
     *
     * @param command the command to be executed
     */
-  def execArgs(command: String*): Try[ListBuffer[String]] = {
+  def execCommand(command: String*): Try[ListBuffer[String]] = {
     Try {
       // Read redirected stdout to a string
       val process  = new ProcessBuilder(command: _*).redirectErrorStream(true).start()
@@ -65,30 +69,27 @@ trait CommandLineTool extends LazyLogging {
       val sink     = new AsyncStreamSink(process.getInputStream, s => stdout.append(s))
       val exitCode = process.waitFor()
 
-      sink.close()
-
       require(exitCode == 0, s"Command did not execute successfully. Exit code: $exitCode")
-
-      stdout
+      yieldAndThen(stdout)(sink.safelyClose())
     }
   }
 
   /** Returns true if the tool is available and false otherwise. */
-  lazy val Available: Boolean = execArgs(Executable +: TestArgs: _*).isSuccess
+  lazy val Available: Boolean = execCommand(Executable +: TestArgs: _*).isSuccess
 }
 
-/** Trait that indicates the executable can run scripts.*/
+/** Indicates the executable can run scripts.*/
 trait ScriptRunner {
   self: CommandLineTool =>
 
-  /** Suffix for scripts that can be run by this tool. */
-  val Suffix: String
+  /** Suffix of scripts that can be run by this tool. */
+  val Suffix: FilenameSuffix
 
   /** Executes a script from the classpath if this executable is available.
     *
+    * @throws Exception when we are unable to execute to this script on the classpath with the given arguments.
     * @param scriptResource the name of the script resource on the classpath
     * @param args a variable list of arguments to pass to the script
-    * @throws Exception when we are unable to execute to this script on the classpath with the given arguments.
     */
   def execIfAvailable(scriptResource: String, args: String*): Unit =
     try { if (Available) exec(scriptResource, args:_*) }
@@ -96,29 +97,27 @@ trait ScriptRunner {
 
   /** Executes a script stored at a Path if the this executable is available.
     *
+    * @throws Exception when we are unable to execute to this script on the classpath with the given arguments.
     * @param script Path of the script to be run
     * @param args a variable list of arguments to pass to the script
-    * @throws Exception when we are unable to execute to this script on the classpath with the given arguments.
     */
   def execIfAvailable(script: Path, args: String*): Unit = execIfAvailable(script.toString, args: _*)
 
-  /** Executes a script from the classpath if this executable is available, raise an exception otherwise.
+  /** Executes a script from the classpath, raise an exception otherwise.
     *
     * @throws ToolException when the exit code from the called process is not zero.
     * @throws Exception when we are unable to execute to this script on the classpath with the given arguments.
     * @param scriptResource the name of the script resource on the classpath
     * @param args a variable list of arguments to pass to the script
-    * @return Unit as this code is side-effecting
     */
   def exec(scriptResource: String, args: String*): Unit = exec(writeResourceToTempFile(scriptResource), args:_*)
 
-  /** Execute from a script stored at a Path if this executable is available, raise an exception otherwise.
+  /** Executes a script from the filesystem Path.
     *
-    * @throws ToolException when the exit code from the called process is not zero.
-    * @throws Exception when we are unable to execute to this script with the given arguments.
-    * @param script Path of the script to be run
+    * @throws ToolException when the exit code from the called process is not zero
+    * @throws Exception when we are unable to execute the script with the given arguments
+    * @param script Path to the script to be executed
     * @param args a variable list of arguments to pass to the script
-    * @return Unit as this code is side-effecting
     */
   def exec(script: Path, args: String*): Unit = try {
     val command = Executable +: script.toAbsolutePath.toString +: args
@@ -132,13 +131,13 @@ trait ScriptRunner {
     if (retval != 0) throw ToolException(retval)
   } catch {case e: Exception => throw new Exception(s"Cannot execute script from path $script with args: $args") }
 
-  /** Extract a resource from the classpath and writes it to a temp file on disk.
+  /** Extracts a resource from the classpath and writes it to a temp file on disk.
     *
     * @param resource a given name on the classpath
     * @return path to the temporary file
     * */
   private def writeResourceToTempFile(resource: String): Path = {
-    val lines = Io.readLinesFromResource(resource).toSeq
+    val lines = Io.readLinesFromResource(resource)
     val path  = Io.makeTempFile("script.", suffix = Suffix)
     path.toFile.deleteOnExit()
     Io.writeLines(path, lines)
@@ -146,6 +145,7 @@ trait ScriptRunner {
   }
 }
 
+/** Defines values used to get the version of the executable. */
 trait Versioned {
   self: CommandLineTool =>
 
@@ -155,10 +155,11 @@ trait Versioned {
   /** Argument used to test version of the executable. */
   val TestArgs: Seq[String] = Seq(VersionFlag)
 
-  /** Return version of this tool */
-  lazy val Version: Try[ListBuffer[String]] = execArgs(Executable +: TestArgs:_*)
+  /** Returns version of this executable. */
+  lazy val Version: Try[ListBuffer[String]] = execCommand(Executable +: TestArgs:_*)
 }
 
+/** Defines methods used to check if specific modules are installed with the executable . */
 trait Modular {
   self: CommandLineTool =>
 
@@ -169,37 +170,47 @@ trait Modular {
   def TestModuleCommand(modules: String*): Seq[Seq[String]] = modules.map(TestModuleCommand)
 
   /** Returns true if the tested module exist with the tested executable. */
-  def ModuleAvailable(module: String): Boolean = execArgs(TestModuleCommand(module): _*).isSuccess
+  def ModuleAvailable(module: String): Boolean = execCommand(TestModuleCommand(module): _*).isSuccess
 
   /** Returns true if all tested modules exist with the tested executable.
     *
     * For example:
     * {{
     * scala> import com.fulcrumgenomics.commons.io._
-    * scala> Rscript.IsModuleAvailable(Seq("ggplot2", "dplyr"))
+    * scala> Rscript.ModuleAvailable(Seq("ggplot2", "dplyr"))
+    * res1: Boolean = true
     * }}
     */
-  def ModuleAvailable(modules: Seq[String]): Boolean =  modules.map(ModuleAvailable).forall(_ == true)
+  def ModuleAvailable(modules: Seq[String]): Boolean =  modules.par.map(ModuleAvailable).forall(_ == true)
 }
 
+/** A collection of values and methods specific for the Rscript executable */
 object Rscript extends CommandLineTool with Versioned with Modular with ScriptRunner {
-  val Executable: String = "Rscript"
-  val Suffix: String     = ".R"
+  val Executable: String     = "Rscript"
+  val Suffix: FilenameSuffix = ".R"
+
+  /** Command to test if a R module exists.
+    *
+    * @param module name of the module to be tested
+    * @return command used to test if a given R module is installed
+    * */
   def TestModuleCommand(module: String): Seq[String] = Seq(Executable, "-e", s"stopifnot(require('$module'))")
 
   /** Only returns true if R exists and ggplot2 is installed */
   override lazy val Available: Boolean = {
-    val ToolAvailable: Boolean   = execArgs(Executable +: Seq(VersionFlag):_*).isSuccess
+    val ToolAvailable: Boolean   = execCommand(Executable +: Seq(VersionFlag):_*).isSuccess
     Seq(ToolAvailable, ModuleAvailable("ggplot2")).forall( _ == true)
   }
 }
 
+/** Defines tools to test various version of python executables */
 trait Python extends CommandLineTool with Versioned with Modular with ScriptRunner {
   val Executable: String
-  val Suffix: String = ".py"
+  val Suffix: FilenameSuffix = ".py"
   def TestModuleCommand(module: String): Seq[String] = Seq(Executable, "-c", s"import $module")
 }
 
+/** Objects specific for different Python versions.  */
 object Python extends Python  { val Executable: String = "python" }
 object Python2 extends Python { val Executable: String = "python2" }
 object Python3 extends Python { val Executable: String = "python3" }


### PR DESCRIPTION
## Background

This PR was originally motivated by [this issue](https://github.com/twinstrandbio/duplex-seq/issues/471#issue-351762260). In order to collate all the pdfs, we need to run the command line tool [Ghostscript](https://www.ghostscript.com/), and do the following:
> - Create a shell command task wrapping gs
> - Only run the task if gs is available on the system path

`Fgbio` has [`Rscript`](https://github.com/fulcrumgenomics/fgbio/blob/master/src/main/scala/com/fulcrumgenomics/util/Rscript.scala) that achieves the same functionality for `R`. To reduce code duplication here we'd like to make a general `CommandLineTool` with the ability to extend to different executables such as R, GS, python, etc.

Nils suggested instead of putting this general `CommandLineTool` into `fgbio`, we should put it into `commons` and deprecate the original [Rscript]((https://github.com/fulcrumgenomics/fgbio/blob/master/src/main/scala/com/fulcrumgenomics/util/Rscript.scala)) in `fgbio`. 

## Changes made in this PR

1. Created a `CommandLineTool` that has some basic functionality to run a command line executable and the possibility to be extended:
	- Check if the executable is available
	- Check if certain modules is installed for the executable, e.g. R or python modules.
	- Run the executable if it is available.

2. Addressed the issue raised [here](https://github.com/fulcrumgenomics/fgbio/issues/397) and had `exec` and `execIfAvailable` both return `Unit` instead of `Try[Unit]`.

3. Currently [`Rscript.Available`](https://github.com/fulcrumgenomics/fgbio/blob/f05508919b647cc086dfc954e6192365e6d58b36/src/main/scala/com/fulcrumgenomics/util/Rscript.scala#L46) only returns **TRUE** when *both Rscript is available AND ggplot2 is installed*. This is a bit confusing so a separate `Rscript.ggplot2Available` is created to check the above instead. We can later deprecate the original `Rscript.Available`.
